### PR TITLE
use parens on bare function calls

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,12 +2,14 @@ defmodule AnalyticsElixir.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :segment,
-     version: "0.1.1",
-     elixir: "~> 1.0",
-     deps: deps,
-     description: "analytics_elixir",
-     package: package]
+    [
+      app: :segment,
+      version: "0.1.1",
+      elixir: "~> 1.0",
+      deps: deps(),
+      description: "analytics_elixir",
+      package: package(),
+    ]
   end
 
   # Configuration for the OTP application

--- a/mix.lock
+++ b/mix.lock
@@ -7,4 +7,4 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "poison": {:hex, :poison, "1.5.2", "560bdfb7449e3ddd23a096929fb9fc2122f709bcc758b2d5d5a5c7d0ea848910", [:mix], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []}}
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:make, :rebar], []}}


### PR DESCRIPTION
Hello, just a tiny change to get rid of warnings from Elixir 1.4:
```
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  ~deps/segment/mix.exs:8

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  ~deps/segment/mix.exs:10
```

(Also, FWIW I noticed `Dict` is used in `segment/http.ex`which is [deprecated entirely](https://hexdocs.pm/elixir/Dict.html#content). I can submit another PR to rewrite using a Map or Keyword if you'd like.) 