### PR TITLE
Delegate Segment.child_spec/1 to adapter

### DIFF
--- a/lib/segment.ex
+++ b/lib/segment.ex
@@ -164,9 +164,7 @@ defmodule Segment do
   By default if nothing is configured it will start `Segment.Analytics.Batcher`
   """
   @spec start_link(String.t()) :: GenServer.on_start()
-  def start_link(api_key) do
-    @service.start_link(api_key)
-  end
+  defdelegate start_link(api_key), to: @service
 
   @doc """
   Start the configured GenServer for handling Segment events with the Segment HTTP Source API Write Key and a custom Tesla Adapter.
@@ -174,7 +172,8 @@ defmodule Segment do
   By default if nothing is configured it will start `Segment.Analytics.Batcher`
   """
   @spec start_link(String.t(), Telsa.adapter()) :: GenServer.on_start()
-  def start_link(api_key, adapter) do
-    @service.start_link(api_key, adapter)
-  end
+  defdelegate start_link(api_key, adapter), to: @service
+
+  @spec child_spec(map()) :: map()
+  defdelegate child_spec(opts), to: @service
 end


### PR DESCRIPTION
In my app I want to wrap `Segment` with a custom `UserAnalytics` module, which I pass to my application supervisor the same way as the Phoenix example in the docs. This supports the following in my module, rather than delegating to the adapter layer directly.

```elixir
  defdelegate start_link(api_key), to: Segment
  defdelegate child_spec(opts), to: Segment

```