### PR TITLE
Include a function clause to handle when a ssl socket is closed

### DIFF
--- a/lib/segment/batcher.ex
+++ b/lib/segment/batcher.ex
@@ -91,6 +91,8 @@ defmodule Segment.Analytics.Batcher do
     {:noreply, {client, queue}}
   end
 
+  def handle_info({:ssl_closed, _msg}, state), do: {:no_reply, state}
+
   # Helpers
   defp schedule_batch_send do
     Process.send_after(self(), :process_batch, Segment.Config.batch_every_ms())


### PR DESCRIPTION
Sometimes the ssl socket is closed and we need to handle it on lib/segment/batcher.ex, so i added a new handle_info function guard.

An issue for this problem still open here: https://github.com/stueccles/analytics-elixir/issues/26