### PR TITLE
Avoid compile-time config for api_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The library has a number of configuration options you can use to overwrite defau
 - `config :segment, :retry_start` The time (in ms) to start the first retry. Default value is 100
 - `config :segment, :send_to_http` If set to `false`, the library will override the Tesla Adapter implementation to only log segment calls to `debug` but not make any actual API calls. This can be useful if you want to switch off Segment for test or dev. Default value is true
 - `config :segment, :tesla, :adapter` This config option allows for overriding the HTTP Adapter for Tesla (which the library defaults to Hackney).This can be useful if you prefer something else, or want to mock the adapter for testing.
-- `config :segment, api_url: "https://self-hosted-segment-api.com/v1/"` The Segment-compatible API endpoint that will receive your events. Defaults to `https://api.segment.io/v1/`. This setting is only useful if you are using a Segment-compatible alternative API like [Rudderstack](https://rudderstack.com/).
+- `config :segment, api_url: "https://self-hosted-segment-api.com/v1/"` The Segment-compatible API endpoint that will receive your events. Defaults to `https://api.segment.io/v1/`. This setting is only useful if you are using Segment's EU instance or a Segment-compatible alternative API like [Rudderstack](https://rudderstack.com/).
 
 ## Usage in Phoenix
 

--- a/lib/segment/client/http.ex
+++ b/lib/segment/client/http.ex
@@ -40,8 +40,6 @@ defmodule Segment.Http do
   require Logger
   use Retry
 
-  @segment_api_url Application.get_env(:segment, :api_url, "https://api.segment.io/v1/")
-
   @doc """
     Create a Tesla client with the Segment Source Write API Key
   """
@@ -66,7 +64,7 @@ defmodule Segment.Http do
   @spec client(String.t(), adapter()) :: client()
   def client(api_key, adapter) do
     middleware = [
-      {Tesla.Middleware.BaseUrl, @segment_api_url},
+      {Tesla.Middleware.BaseUrl, Segment.Config.api_url()},
       Tesla.Middleware.JSON,
       {Tesla.Middleware.BasicAuth, %{username: api_key, password: ""}}
     ]

--- a/lib/segment/config.ex
+++ b/lib/segment/config.ex
@@ -1,6 +1,10 @@
 defmodule Segment.Config do
   @moduledoc false
 
+  def api_url do
+    Application.get_env(:segment, :api_url, "https://api.segment.io/v1/")
+  end
+
   def service do
     Application.get_env(:segment, :sender_impl, Segment.Analytics.Batcher)
   end


### PR DESCRIPTION
This fixes possible problems when configuring the `api_url` and follows the same pattern as the other available configurations and the [Elixir guide](https://hexdocs.pm/elixir/library-guidelines.html#avoid-compile-time-application-configuration). 

