### PR TITLE
Named GernServer Segment Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ Start the Segment agent with your write_key from Segment for a HTTP API Server S
 Segment.start_link("YOUR_WRITE_KEY")
 ```
 
+Alternatively, a named segment agent can be started using a keyword list:
+
+```elixir
+# Not supplying the name will default to the module name
+opts = [name: MySegmentAgent, api_key: "YOUR_WRITE_KEY"]
+Segment.start_link(opts)
+```
+
+The following options are currently supported:
+ - `:api_key` (required)
+ - `:adapter` (optional)
+ - `:name`    (optional)
+
 There are then two ways to call the different methods on the API.
 A basic way through `Segment.Analytics` functions with either the full event Struct
 or some helper methods (also allowing Context and Integrations to be set manually).

--- a/lib/segment.ex
+++ b/lib/segment.ex
@@ -12,14 +12,21 @@ defmodule Segment do
           | Segment.Analytics.Group.t()
           | Segment.Analytics.Page.t()
 
+  def start_link(opts \\ [])
+
   @doc """
   Start the configured GenServer for handling Segment events with the Segment HTTP Source API Write Key
 
   By default if nothing is configured it will start `Segment.Analytics.Batcher`
   """
   @spec start_link(String.t()) :: GenServer.on_start()
-  def start_link(api_key) do
+  def start_link(api_key) when is_binary(api_key) do
     Segment.Config.service().start_link(api_key)
+  end
+
+  @spec start_link(Segment.Analytics.Batcher.options()) :: GenServer.on_start()
+  def start_link(opts) when is_list(opts) do
+    Segment.Config.service().start_link(opts)
   end
 
   @doc """


### PR DESCRIPTION
This PR allows the default `Segment.Analytics.Batcher` GenServer to be started with a keyword list supporting the following options:

 - `:api_key` (required)
 - `:adapter` (optional)
 - `:name`    (optional)

For example:

```elixir
def child_specs() do
  ....,
 {Segment, api_key: "YOUR_WRITE_KEY", name: MySegmentAgent},
 ...
end

# or

opts = [name: MySegmentAgent, api_key: "YOUR_WRITE_KEY"]
Segment.start_link(opts)
```

Rationale:
For an elixir umbrella app, it is currently not possible to start multiple Segment batcher agents with separate write keys. Allowing optional parameters overcomes this limitation.

Cheers!
 